### PR TITLE
Allow custom http.Client to be passed in to constructor

### DIFF
--- a/azure.go
+++ b/azure.go
@@ -58,21 +58,29 @@ const apiVersion = "2016-07"
 
 //New creates a new client from the given parameters. Their meaning can be found in the MSDN docs at:
 //  https://docs.microsoft.com/en-us/rest/api/servicebus/Introduction
-func newClient(clientType ClientType, namespace string, sharedAccessKeyName string, sharedAccessKeyValue string) *client {
+func newClient(clientType ClientType, namespace string, sharedAccessKeyName string, sharedAccessKeyValue string, httpClient *http.Client) *client {
 	return &client{
 		clientType: clientType,
 		namespace:  namespace,
 		saKey:      sharedAccessKeyName,
 		saValue:    []byte(sharedAccessKeyValue),
 		url:        fmt.Sprintf(serviceBusURL, namespace),
-		client:     &http.Client{},
+		client:     httpClient,
 	}
 }
 
 //New creates a new client from the given parameters. Their meaning can be found in the MSDN docs at:
 //  https://docs.microsoft.com/en-us/rest/api/servicebus/Introduction
 func New(clientType ClientType, namespace string, sharedAccessKeyName string, sharedAccessKeyValue string) Client {
-	return newClient(clientType, namespace, sharedAccessKeyName, sharedAccessKeyValue)
+	return newClient(clientType, namespace, sharedAccessKeyName, sharedAccessKeyValue, &http.Client{})
+}
+
+//NewWithHttpClient creates a new client with a custom http.Client
+func NewWithHttpClient(clientType ClientType, namespace string, sharedAccessKeyName string, sharedAccessKeyValue string, httpClient *http.client) Client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	return newClient(clientType, namespace, sharedAccessKeyName, sharedAccessKeyValue, httpClient)
 }
 
 //SetSubscription sets the client's subscription. Only required for Azure Service Bus Topics.


### PR DESCRIPTION
Allowing custom http.Clients to be passed into constructor will allow the caller to set specific configurations for the outbound http(s) calls. 

For example, if the caller wants to enforce TLS1.2, this PR makes that possible.